### PR TITLE
eun61n00_231009: 5/5/0

### DIFF
--- a/baekjoon/Q15486_eun61n00.py
+++ b/baekjoon/Q15486_eun61n00.py
@@ -1,0 +1,23 @@
+# !/usr/bin/env python
+#  -*- coding: utf-8 -*-
+# boj 15486 퇴사2
+
+import sys
+
+input = sys.stdin.readline
+
+n = int(input())
+dp = [0] * (n + 1)
+meetings = [list(map(int, input().split())) for _ in range(n)]
+meetings.insert(0, [0, 0])
+
+# DP 풀이
+profit = 0
+for i in range(1, n + 1):
+    end_date = i + meetings[i][0] - 1  # i일에 시작한 상담이 끝나는 날
+    profit = max(profit, dp[i - 1])  # i일까지의 최대 수익
+    if end_date <= n:  # 상담이 끝나는 날이 퇴사일을 넘지 않으면
+        # 점화식 (현재 저장된 최대 수익과 i-1일까지의 최대 수익 + i일 상담 수익을 비교)
+        dp[end_date] = max(dp[end_date], profit+meetings[i][1])
+
+print(max(dp))

--- a/baekjoon/Q1759_eun61n00.py
+++ b/baekjoon/Q1759_eun61n00.py
@@ -1,0 +1,32 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+# boj 1759 암호 만들기
+
+l, c = map(int, input().split())
+characters = list(map(str, input().split()))
+characters.sort()
+
+
+def backtracking(password, idx):
+    if is_possible(password):
+        print(password)
+
+    for i in range(idx + 1, len(characters)):
+        password += characters[i]
+        backtracking(password, i)
+        password = password[:-1]
+
+
+def is_possible(password):
+    abc, aeiou = 0, 0
+    for i in password:
+        if i in ["a", "e", "i", "o", "u"]:
+            aeiou += 1
+        else:
+            abc += 1
+    if abc >= 2 and aeiou >= 1 and len(password) == l:
+        return True
+    return False
+
+
+backtracking("", -1)

--- a/baekjoon/Q2758_eun61n00.py
+++ b/baekjoon/Q2758_eun61n00.py
@@ -1,0 +1,48 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+# boj 2758 로또
+
+
+# Backtracking 풀이 - 시간 초과
+def backtracking(n, m, lotto):
+    print(f"backtracking: {lotto}")
+    if len(lotto) == n - 1:
+        global answer
+        # answer += 1
+        answer += (m - (lotto[-1] * 2) + 1)
+        print(lotto, answer)
+        return
+    for i in range(lotto[-1]*2, m + 1):
+        tmp = i
+        for j in range(n - len(lotto) - 1):
+            tmp *= 2
+            if tmp > m:
+                return
+        lotto.append(i)
+        backtracking(n, m, lotto)
+        lotto.pop()
+
+
+t = int(input())
+for _ in range(t):
+    n, m = map(int, input().split())
+    answer = 0
+    for i in range(1, m + 1):
+        if i**n <= m:
+            backtracking(n, m, [i])
+    print(answer)
+
+
+# DP 풀이
+t = int(input())
+for _ in range(t):
+    n, m = map(int, input().split())
+
+    dp = [[0]*(m+1) for _ in range(n+1)]
+    for i in range(m + 1):
+        dp[1][i] = i
+
+    for i in range(2, n + 1):
+        for j in range(1, m + 1):
+            dp[i][j] = dp[i][j-1]+dp[i-1][j//2]
+    print(dp[n][m])

--- a/baekjoon/Q4179_eun61n00.py
+++ b/baekjoon/Q4179_eun61n00.py
@@ -1,0 +1,84 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+# boj 4179 불!
+
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+h, w = map(int, input().split())
+visited = [[False] * w for _ in range(h)]
+
+graph = []
+for _ in range(h):
+    graph.append(list(input())[:w])
+
+fire_start = []
+for i in range(h):
+    for j in range(w):
+        if graph[i][j] == "J":
+            jihoon_start = (i, j)
+            graph[i][j] = 0
+        elif graph[i][j] == "F":
+            fire_start.append((i, j))
+
+dy = [-1, 1, 0, 0]
+dx = [0, 0, -1, 1]
+answer = 0
+
+
+def fire_bfs(start):
+    global graph, w, h
+    fire = deque([])
+    visited = [[False] * w for _ in range(h)]
+    for s in start:
+        y, x = s
+        fire.append((y, x))
+        visited[y][x] = True
+
+    while fire:
+        y, x = fire.popleft()
+
+        for i in range(4):
+            ny, nx = y + dy[i], x + dx[i]
+
+            if ny < 0 or nx < 0 or ny > h - 1 or nx > w - 1:
+                continue
+            if visited[ny][nx] == False and graph[ny][nx] != "#":
+                graph[ny][nx] = graph[y][x] + "F"
+                visited[ny][nx] = True
+                fire.append((ny, nx))
+
+
+def jihoon_bfs(start):
+    global graph, w, h
+    y, x = start
+    jihoon = deque([(y, x)])
+    graph[y][x] = 0
+    visited = [[False] * w for _ in range(h)]
+    visited[y][x] = True
+
+    while jihoon:
+        y, x = jihoon.popleft()
+
+        for i in range(4):
+            ny, nx = y + dy[i], x + dx[i]
+
+            if ny < 0 or nx < 0 or ny > h - 1 or nx > w - 1:
+                return graph[y][x] + 1
+            if visited[ny][nx] == False and graph[ny][nx] != "#":
+                if graph[ny][nx] == "." or graph[ny][nx].count("F") - 1 > graph[y][x] + 1:
+                    visited[ny][nx] = True
+                    jihoon.append((ny, nx))
+                    graph[ny][nx] = graph[y][x] + 1
+
+    return -1
+
+
+fire_bfs(fire_start)
+answer = jihoon_bfs(jihoon_start)
+if answer > -1:
+    print(answer)
+else:
+    print("IMPOSSIBLE")

--- a/baekjoon/Q7576_eun61n00.py
+++ b/baekjoon/Q7576_eun61n00.py
@@ -1,0 +1,71 @@
+# !/usr/bin/env python
+# -*- coding: utf-8 -*-
+# boj 7576 토마토
+
+import sys
+from collections import deque
+
+input = sys.stdin.readline
+
+m, n, o = map(int, input().split())
+
+graph = [[] for _ in range(o)]
+visited = [[[False] * m for _ in range(n)] for _ in range(o)]
+
+tomato_idx = []
+
+for i in range(o):
+    for j in range(n):
+        tomatoes = list(map(int, input().split()))
+        graph[i].append(tomatoes)
+        for k, tomato in enumerate(tomatoes):
+            if tomato == 1:
+                tomato_idx.append((k, j, i))
+
+
+dx = [-1, 1, 0, 0, 0, 0]
+dy = [0, 0, -1, 1, 0, 0]
+dh = [0, 0, 0, 0, -1, 1]
+answer = 0
+
+
+def bfs(graph, start, visited):
+    global answer
+    queue = deque([])
+    for s in start:
+        x, y, h = s
+        queue.append((x, y, h))
+        visited[h][y][x] = True
+
+    while queue:
+        x, y, h = queue.popleft()
+
+        for i in range(6):
+            nx, ny, nh = x+dx[i], y+dy[i], h+dh[i]
+
+            if nx < 0 or ny < 0 or nh < 0 or nx >= m or ny >= n or nh >= o:
+                continue
+            if visited[nh][ny][nx] == False and graph[nh][ny][nx] == 0:
+                graph[nh][ny][nx] = graph[h][y][x] + 1
+                answer = max(answer, graph[nh][ny][nx])
+                queue.append((nx, ny, nh))
+                visited[nh][ny][nx] = True
+
+    return graph
+
+
+graph = bfs(graph, tomato_idx, visited)
+
+
+# 안익은 토마토가 있음에도 익히지 못함
+for h in graph:
+    if any(0 in i for i in h):
+        answer = -1
+        break
+
+if answer > 0:  # 첫날은 정답에서 빼기
+    answer -= 1
+elif answer == 0:  # 익힌 토마토가 없음
+    answer = 0
+
+print(answer)


### PR DESCRIPTION
## ⭐ 규칙

<details>

  <summary>첫 PR 작성시 꼭 읽어주세요!</summary>

1. PR 제목 (`feature`은 기재 X)</br>
   {브랜치 이름}: {목표 문제 수}/{푼 문제 수}/{못 푼 문제 수}</br>
   **(예시) kkc217_230928: 3/3/0**

2. 내용</br>
   **문제 개수**만큼 템플릿울 복붙해 내용을 작성해주세요.
   </details>

</br>

## 체크 리스트

-   [x] 규칙에 맞게 PR 제목을 수정함.
-   [x] 푼 문제만큼 설명을 작성함.
-   [x] Reviewer를 추가함.

</br>

## 💬 문제 공유

### 1. Q4179(불!):

-   [문제 링크](https://www.acmicpc.net/problem/4179)
-   난이도: 4 / 5 <!-- 본인이 느낀 난이도를 기입해주세요. -->
-   지훈이가 미로에서 탈출할 수 있는 최소 거리를 구하는 전형적인 BFS 문제이지만 불도 같이 사방으로 확산하기 때문에 움직이는 객체가 2개인 BFS 문제

1. 미로 정보와 지훈이와 불의 초기 위치 정보 저장

-   미로 정보를 `graph`에 저장 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q4179_eun61n00.py#L13-L15)
-   `graph`에서 지훈이의 초기 위치(`"J"`)와 불의 초기 위치( )를 각각 `jihoon_start`와 `fire_start`에 저장 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q4179_eun61n00.py#L17-L24)

2. [불의 확산 정보 저장하기](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q4179_eun61n00.py#L31-L52)
-   시간이 지날 때에 불이 먼저 확산되고 확산된 곳에는 지훈이가 이동할 수 없기 때문에 불의 확산 정보를 미리 저장
-   불은 매 시간마다 사방(위, 아래, 왼쪽, 오른쪽)으로 확산되기 때문에 bfs 알고리즘을 사용해 확산 정보를 저장
-   불의 확산 정보는 시간 정보와 함께 저장되어야 하기 때문에 시간이 지날 수록 F의 개수를 늘려서 `graph`에 저장
![](https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2Fu7jJt%2Fbtsysrxy38W%2FJqwwAfkms7UcOOiXJdKx7k%2Fimg.png)


3. [지훈이 이동시키기](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q4179_eun61n00.py#L54-L76)

-   지훈이도 마찬가지로 사방으로 이동 가능하기 때문에 bfs 알고리즘을 사용해서 최단 거리를 구함
-   이 때, 이동가능한 경우는 `graph[ny][nx]`가 `"."`일 때와 불이 확산된 시간(`graph[ny][nx].count("F") - 1`)보다 지훈이의 현재 이동 시간(`graph[y][x] + 1`)이 작을 때 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q4179_eun61n00.py#L70C13-L75)
-   `ny`, `nx`가 `graph`의 범위를 벗어나면 지훈이가 탈출했다는 의미이므로 최단 경로(`graph[y][x] + 1`)을 리턴하고, 지훈이가 이동할 수 있는 경우를 모두 탐색했음에도 `graph`를 벗어나지 못했다면 탈출을 못한다는 의미이므로 `-1`을 return [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q4179_eun61n00.py#L68C13-L69)

</br>
</br>

### 2. Q7576(토마토):

-   [문제 링크](https://www.acmicpc.net/problem/7569)
-   난이도: 3 / 5 <!-- 본인이 느낀 난이도를 기입해주세요. -->
-   시작점이 여러개인 BFS 문제 (익음 토마토가 여러개 이므로)
-   [graph가 3차원](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q7576_eun61n00.py#L12-L13), [이동 방향도 6개](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q7576_eun61n00.py#L26-L28)

1. [시작점 모두 저장(익은 토마토 위치 모두 저장)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q7576_eun61n00.py#L17-L23) - 익은 토마토에 인접한 토마토를 익혀야 하므로 익은 토마토가 BFS 알고리즘의 시작점이 되고 이 시작점이 여러개인 구조임
2. 시작점이 여러개이지만 [모든 시작점을 queue에 넣고 시작](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q7576_eun61n00.py#L35-L38)하고 이후에는 [전형적인 BFS 알고리즘 수행](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q7576_eun61n00.py#L40-L52)
3. 안익은 토마토가 있는지 검사 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q7576_eun61n00.py#L60-L64)

</br>
</br>

### 3. Q2758(로또):

-   [문제 링크](https://www.acmicpc.net/problem/2758)
-   난이도: 4 / 5 (DP가 젤 어려워,,) <!-- 본인이 느낀 난이도를 기입해주세요. -->
-   m이하의 자연수 중에서 n개의 숫자를 규칙에 맞춰서 고르는 문제로 전형적인 백트랙킹 문제로 생각했으나 시간 초과..! [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q2758_eun61n00.py#L6-L33)
-   따라서 DP로 풀어야 함 -> DP 배열은 2차원으로 `dp[i][j]`에 `j`이하의 자연수로 길이 `i`의 로또 번호를 만드는 방법을 저장 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q2758_eun61n00.py#L41-L43)
-   점화식: `dp[i][j] = dp[i][j-1] + dp[i-1][j//2]` [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q2758_eun61n00.py#L47)
![](https://img1.daumcdn.net/thumb/R1280x0/?scode=mtistory2&fname=https%3A%2F%2Fblog.kakaocdn.net%2Fdn%2FKK51y%2FbtsytiNznKq%2FZZQQ39SS5kqLiSF3KVTrTK%2Fimg.png)
-   ex. n=4이고, m=10인 경우) `dp[4][10] = dp[3][5] + dp[4][9]`
    <br/>10 이하의 자연수로 로또 번호 4개를 고르면 되므로 9이하의 자연수로 4개의 로또 번호를 고르는 경우가 포함되고, 5 이하의 자연수로 3개를 골라놓은 경우에 5의 2배인 10을 추가로 넣어주면되기 때문
    </br>
    </br>

### 4. Q1759(암호만들기):

-   [문제 링크](https://www.acmicpc.net/problem/1759)
-   난이도: 3 / 5 <!-- 본인이 느낀 난이도를 기입해주세요. -->
-   백트랙킹으로 풀이
-   백트랙킹으로 탐색할 때마다 `is_possible()`함수로 비밀번호가 될 수 있는지 확인
-   [모든 자식 노드에 대해 for문으로 순회](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q1759_eun61n00.py#L14)하며 [자식 노드(다음 상태)로 이동](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q1759_eun61n00.py#L15) 후, [backtracking 탐색](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q1759_eun61n00.py#L16), [다시 부모 노드(이전 상태)로 이동](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q1759_eun61n00.py#L17)
    </br>
    </br>

### 5. Q15486(퇴사2):

-   [문제 링크](https://www.acmicpc.net/problem/15486)
-   난이도: 4 / 5 (DP 어려워여) <!-- 본인이 느낀 난이도를 기입해주세요. -->
-   퇴사일과 각 일마다 상담에 소요되는 일수와 받을 수 있는 금액이 주어질 때, 얻을 수 있는 최대 이익을 출력하는 문제
-   백준 14501 퇴사 문제와 같은 문제인데, 시간복잡도를 줄여서 제출해야 맞출 수 있음

1. 풀이1 - 시간 초과

```
dp = [0 for _ in range(n + 1)]
for i in range(n):
    # i일 상담 진행했을 때 상담 가능한 날부터 돌기
    for j in range(i + meetings[i][0], n + 1):
        dp[j] = max(dp[j], dp[i] + meetings[i][1])

print(dp[-1])
```

-   `dp[i]`에는 `i`일까지 일했을 때의 최대 수익을 저장
-   풀이1에서는 `dp` 배열을 완벽하게 채움. 즉, 1일부터 `n`일까지 얻을 수 있는 최대 수익을 모두 저장
-   2중 for문을 사용하여 i일에 시작한 상담이 끝나는 날부터 퇴사일까지 끝까지 순회
-   따라서 가장 마지막날을 바로 출력하면 퇴사일(`n`일)의 최대 수익을 출력
-   하지만 이렇게 2중 for문을 돌게 되면 15486번 문제에서는 시간 초과 발생

2. 풀이2

-   풀이1과는 다르게 i일에 시작한 상담이 끝나는 날의 `dp`만 업데이트 (풀이1에서는 상담이 끝나는 날부터 퇴사일까지 끝까지 순회하도록 for문을 한 번 더 사용함)
-   대신, `i-1`까지의 최대 수익을 담고 있는 `profit` 변수를 사용하여[(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q15486_eun61n00.py#L18) `i-1`일까지의 최대 수익에 `i`일 상담 수익을 더하여 `i`일에 시작한 상담이 끝나는 날의 최대 수익을 업데이트
-   따라서 `dp[end_date]`의 값은 이미 저장되어있는 `dp[end_date]`와 `profit`(i-1일까지의 최대 수익)`+meetings[i][1]`(i일의 상담 수익)을 비교하여 더 큰 값으로 갱신 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q15486_eun61n00.py#L21)
-   그리고 마지막에는 `dp[n]`이 아닌 `max(dp)`를 출력: 왜냐하면 for문을 한번만 사용하여 i일에 시작한 상담이 끝나는 날의 `dp` 값만 업데이트되기 때문에 만약, 마지막 날에 끝나는 상담이 없다면 `dp` 값이 갱신되지 않음. 따라서 `dp` 배열의 최댓값을 출력하여 최대 수익을 출력 [(코드)](https://github.com/kkc217/Algorithm-Study/blob/f03b1a5a11f3fd11285c0ac96109cb48cf89652c/baekjoon/Q15486_eun61n00.py#L23)

      </br>
      </br>
